### PR TITLE
bring docstrings closer to conventions in Julia Manual

### DIFF
--- a/src/Signals.jl
+++ b/src/Signals.jl
@@ -23,34 +23,37 @@ include("time.jl")
 
 
 @doc """
-    S = Signal(val;strict_push = false)
-Create a source `Signal` with initial value `val`, setting
-`strict_push` to `true` gurrantees that every push to this `Signal`
-will be carried out independently. otherwise if updates occur faster than what the `eventloop`
-can process, then only the last value before the `evetloop` kicks in will be used(*defualt*)
+    S = Signal(val; strict_push = false)
 
-    S = Signal(f,args...;v0 = nothing)
-Creates a derived `Signal` whos value is `f(args...)` , args can be of any type
+Create a source `Signal` with initial value `val`, setting `strict_push` to `true`
+guarantees that every push to this `Signal` will be carried out independently.
+Otherwise if updates occur faster than what the `eventloop` can process, then only
+the last value before the `eventloop` kicks in will be used(*default*).
+
+    S = Signal(f,args...; v0 = nothing)
+
+Create a derived `Signal` whos value is `f(args...)` , args can be of any type
 ,`Signal` args get replaced by their value before calling `f(args...)`. reads best with
 with `do` notation(see example).if `v0` is not `nothing` then `f(args...)` will not
 be called directly after Signal creation instead the Signal will be initialized to have value v0
 
+# Syntax
 
-
-## Syntax
     S[] = val
-sets the value of `S` to `val` without propogating the change to the rest of the signal graph,
-usefull in pull based paradigm
+Set the value of `S` to `val` without propogating the change to the rest of the signal graph,
+usefull in pull based paradigm.
 
     S()
-`pull!` Signal, pulling any changes in the Signal graph that affects `S`
+`pull!` Signal, pulling any changes in the Signal graph that affects `S`.
 
     S(val)
-sets the value of `S` to `val` and pushes the changes along the Signal graph
+Set the value of `S` to `val` and pushes the changes along the Signal graph.
 
     S[]
-gets the current value stored in `S` without pulling changes from the graph
-## Example
+Get the current value stored in `S` without pulling changes from the graph.
+
+# Examples
+
     julia> A = Signal(1) #source Signal
     Signal
     value: 1

--- a/src/async_remote.jl
+++ b/src/async_remote.jl
@@ -1,9 +1,9 @@
 @noinline call_no_inline(f,args) = f(args...)
 """
     s = async_signal(f, args...; init = nothing)
-create a signal initialized to `init` whos action `f(args...)`  will run asynchronously in a different task
-whenever its arguments update.async signals only work
-in a push based paradigm.
+
+Create a signal initialized to `init` whos action `f(args...)`  will run asynchronously in a
+different task whenever its arguments update.async signals only work in a push based paradigm.
 """
 function async_signal(f, args...; init = nothing)
     res = Signal(init)
@@ -22,9 +22,10 @@ end
 export async_signal
 
 """
-    s = remote_signal(f args...;init = nothing, procid = first(workers()) )
-create a signal initialized to `init` whos action `f(args...)`  will run remotely in a process
-with id `procid` , whenever its arguments update.remote signals only work
+    s = remote_signal(f, args...; init = nothing, procid = first(workers()))
+
+Create a signal initialized to `init` whos action `f(args...)` will run remotely in
+a process with id `procid`, whenever its arguments update.remote signals only work
 in a push based paradigm.
 """
 function remote_signal(f,args...;init = nothing, procid = first(workers()) )

--- a/src/bind.jl
+++ b/src/bind.jl
@@ -2,7 +2,7 @@
 """
     bind!(dest::Signal, src::Signal)
 
-for every update to `src` also update `dest` with the same value
+For every update to `src` also update `dest` with the same value.
 """
 function bind!(dest::Signal, src::Signal)
     push!(dest.binders,Signal(x->dest(x),src))
@@ -12,11 +12,11 @@ export bind!
 """
     unbind!(dst::Signal,src::Signal)
 
-remove bindings from `src` to `dst` that were previously created using `bind`
+Remove bindings from `src` to `dst` that were previously created using `bind`.
 
     unbind!(dst::Signal)
 
-remove all bindings that were previously created using `bind` that will cause `dst` to update
+Remove all bindings that were previously created using `bind` that will cause `dst` to update.
 """
 function unbind!(dst::Signal,src::Signal)
     b_idx  = findfirst(b->b.action.args[1] == src,dst.binders)
@@ -39,7 +39,7 @@ import Base.detach
 """
     detach(s::Signal)
 
-detach a signal `s` from the signal graph making it unreachable and ready for GC.
+Detach a signal `s` from the signal graph making it unreachable and ready for GC.
 """
 function detach(s::Signal)
     parents = Iterators.filter(x->isa(x,Signal),s.action.args)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -27,7 +27,7 @@ import Base.filter
 """
     filter(f, default, signal)
 
-remove updates from the `signal` where `f` does not return `true`. The filter will hold
+Remove updates from the `signal` where `f` does not return `true`. The filter will hold
 the value default until f(value(signal)) returns true, when it will be updated
 to value(signal).
 """
@@ -51,12 +51,13 @@ end
 
 abstract type When <: PullType end
 """
-    when(f, condition::Signal, args... ; v0 = nothing)
+    when(f, condition::Signal, args...; v0 = nothing)
 
-creates a `Signal` that will update to `f(args...)` when any of its input `args`
-updates *only if* `condition` has value `true`. if `condition != true` in
-the time of creation the signal will be initialized to value `v0`
-# Example
+Create a `Signal` that will update to `f(args...)` when any of its input `args`
+updates *only if* `condition` has value `true`. If `condition != true` in
+the time of creation the signal will be initialized to value `v0`.
+
+# Examples
 
     julia> A = Signal(1)
     julia> condition = Signal(A) do a

--- a/src/pushpull.jl
+++ b/src/pushpull.jl
@@ -15,9 +15,10 @@ function push!(s::Signal,val,async = async_mode())
 end
 
 """
-    strict_push!(s::Signal,val,async = Signals.async_mode() )
-sets `s` to `val` and propagate into derived signals, is `async` is `true`(default)
-then updates to derived signals will occur asynchronically
+    strict_push!(s::Signal, val, async = Signals.async_mode())
+
+Set `s` to `val` and propagate into derived signals, is `async` is `true`(default)
+then updates to derived signals will occur asynchronically.
 """
 function strict_push!(s,val,async = async_mode())
     if !async || isempty(pull_queue)

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,12 +1,12 @@
 """
     s = buffer(input; buf_size = Inf, timespan = 1, type_stable = false)
-creates a signal who buffers updates to signal `input` until maximum size of `buf_size`
-or until `timespan` seconds have passed. The signal value is the last
-full buffer emitted or an empty vector if the buffer have never
-been filled before.
 
-buffer type will be `Any` unless `type_stable` is set to `true`, then it will be set
-to the value of the first encountered item
+Create a signal whos buffers updates to signal `input` until maximum size of `buf_size`
+or until `timespan` seconds have passed. The signal value is the last full buffer emitted
+or an empty vector if the buffer have never been filled before.
+
+Buffer type will be `Any` unless `type_stable` is set to `true`, then it will be set
+to the value of the first encountered item.
 """
 
 function buffer(input; buf_size = Inf, timespan = 1, type_stable = false)
@@ -27,10 +27,11 @@ end
 export buffer
 
 """
-    debounce(f,args...;delay = 1 , v0 = nothing)
-Creates a `Signal` whos action `f(args...)` will be called only after `delay` seconds have passed since the last time
-its `args` were updated. only works in push based paradigm. if v0 is not specified
-then the initial value is `f(args...)`
+    debounce(f, args...; delay = 1, v0 = nothing)
+
+Create a `Signal` whos action `f(args...)` will be called only after `delay` seconds
+have passed since the last time its `args` were updated. Only works in push based paradigm.
+If `v0` is not specified then the initial value is `f(args...)`.
 """
 function debounce(f,args...;delay = 1 , v0 = nothing)
     timer = Timer(identity,0)
@@ -46,10 +47,11 @@ export debounce
 
 abstract type Throttle <: PullType end
 """
-    throttle(f::Function,args...;maxfps = 0.03)
-Creates a throttled `Signal` whos action `f(args...)` will be called only
+    throttle(f::Function, args...; maxfps = 0.03)
+
+Create a throttled `Signal` whos action `f(args...)` will be called only
 if `1/maxfps` time has passed since the last time it updated. The resulting `Signal`
-will be updated maximum of `maxfps` times per second
+will be updated maximum of `maxfps` times per second.
 """
 function throttle(f::Function,args... ; maxfps = 30)
     pa = PullAction(f,args,Throttle)
@@ -89,9 +91,9 @@ activate_timer(s,dt,duration) = begin
 end
 
 """
-    s = every(dt;duration = Inf)
+    s = every(dt; duration = Inf)
 
-A signal that updates every `dt` seconds to the current timestamp, for `duration` seconds
+A signal that updates every `dt` seconds to the current timestamp, for `duration` seconds.
 """
 function every(dt;duration  = Inf)
     res = Signal(time())
@@ -101,9 +103,9 @@ end
 export every
 
 """
-    s = fps(freq;duration = Inf)
+    s = fps(freq; duration = Inf)
 
-A signal that updates `freq` times a second to the current timestamp, for `duration` seconds
+A signal that updates `freq` times a second to the current timestamp, for `duration` seconds.
 """
 function fps(freq;duration  = Inf)
     every(1/freq; duration = duration)
@@ -111,7 +113,7 @@ end
 export fps
 
 """
-    s = fpswhen(switch::Signal,freq;duration = Inf)
+    s = fpswhen(switch::Signal, freq; duration = Inf)
 
 A signal that updates 'freq' times a second to the current timestamp, for `duration` seconds
 if and only if the value of `switch` is `true`.
@@ -131,10 +133,14 @@ end
 export fpswhen
 
 """
-     s = for_signal(f::Function,range,args...; fps = 1)
-creates a `Signal` that updates to `f(i,args....) for i in range` every `1/fps` seconds.
-`range` and `args` can be of type `Signal` or any other type. The loop starts whenever one of the agruments or when `range` itself updates. If the
-previous for loop did not complete it gets cancelled. For example:
+     s = for_signal(f::Function, range, args...; fps = 1)
+
+Create a `Signal` that updates to `f(i,args....) for i in range` every `1/fps` seconds.
+`range` and `args` can be of type `Signal` or any other type. The loop starts whenever
+one of the arguments or when `range` itself updates. If the previous for loop did not
+complete it gets cancelled.
+
+# Examples
 
     range = Signal(1:5)
     A = Signal(2)


### PR DESCRIPTION
Changes include: blank line between signature block and one-line sentence,
imperative form, break after 92 characters and end with period. Some
typos; add spaces in signature arguments.