### PR TITLE
use normal function form instead of begin..end

### DIFF
--- a/src/Signal.jl
+++ b/src/Signal.jl
@@ -16,7 +16,7 @@ struct Signal
     state::Ref
 end
 
-store!(sd::SignalData,val) = begin
+function store!(sd::SignalData,val)
      sd.propogated = false
      sd.valid = true;
      sd.x = val
@@ -41,12 +41,11 @@ propogated(sd::SignalData,val::Bool) = sd.propogated = val
 valid(s::Signal) = valid(s.data)
 valid(sd::SignalData) = sd.valid
 
-Signal(val;kwargs...) = begin
-    Signal(()->val;kwargs...)
-end
+Signal(val;kwargs...) = Signal(()->val;kwargs...)
 
 abstract type Stateless end
-Signal(f::Function,args...;state = Stateless ,strict_push = false ,pull_type = StandardPull, v0 = nothing) = begin
+function Signal(f::Function,args...;state = Stateless ,strict_push = false,
+                pull_type = StandardPull, v0 = nothing)
     _state = Ref(state)
     if state != Stateless
         args = (args...,_state)
@@ -58,7 +57,7 @@ Signal(f::Function,args...;state = Stateless ,strict_push = false ,pull_type = S
     s
 end
 
-Signal(sd::SignalData,action::PullAction,state = Stateless, strict_push = false) = begin
+function Signal(sd::SignalData,action::PullAction,state = Stateless, strict_push = false)
     debug_mode() && finalizer(sd,x-> @schedule println("signal deleted"))
 
     s = Signal(sd,action,Signal[],Signal[],strict_push,Ref(state))
@@ -90,12 +89,12 @@ function invalidate!(s::Signal)
     end
 end
 
-invalidate!(sd::SignalData) = begin
+function invalidate!(sd::SignalData)
     sd.valid = false
     sd.propogated = false
 end
 
-validate(s::Signal) = begin
+function validate(s::Signal)
     valid(s) && return
     if valid(s.action)
         validate(s.data)
@@ -103,7 +102,7 @@ validate(s::Signal) = begin
     end
 end
 
-validate(sd::SignalData) = begin
+function validate(sd::SignalData)
     sd.propogated = false
     sd.valid = true
 end
@@ -111,7 +110,7 @@ end
 import Base.show
 show(io::IO, s::Signal) = show(io,MIME"text/plain"(),s)
 
-show(io::IO, ::MIME"text/plain", s::Signal) = begin
+functon show(io::IO, ::MIME"text/plain", s::Signal)
     state_str = "\nstate{$(typeof(s.state.x))}: $(s.state.x)"
     state_str = state(s) == Signals.Stateless ? "" : state_str
     valid_str = valid(s) ? "" : "(invalidated)"

--- a/src/Signal.jl
+++ b/src/Signal.jl
@@ -110,7 +110,7 @@ end
 import Base.show
 show(io::IO, s::Signal) = show(io,MIME"text/plain"(),s)
 
-functon show(io::IO, ::MIME"text/plain", s::Signal)
+function show(io::IO, ::MIME"text/plain", s::Signal)
     state_str = "\nstate{$(typeof(s.state.x))}: $(s.state.x)"
     state_str = state(s) == Signals.Stateless ? "" : state_str
     valid_str = valid(s) ? "" : "(invalidated)"

--- a/src/error.jl
+++ b/src/error.jl
@@ -5,7 +5,7 @@ function isatom()
         Main.Juno._active == true
 end
 
-handle_err(e,st) = begin
+function handle_err(e,st)
     if isatom() && debug_mode() == false
         st = clean_stacktrace(st)
         ee = Main.Atom.EvalError(e,st)
@@ -17,7 +17,7 @@ handle_err(e,st) = begin
     end
 end
 
-clean_stacktrace(st) = begin
+function clean_stacktrace(st)
     idx = findfirst([sf.func == :pull! for sf in st])
     idx = idx == 0 ? length(st) : idx
     idx = idx == 1 ? 2 : idx

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -9,7 +9,7 @@ as the previous value of the signal.
 droprepeats(s) = Signal(x->x,s;pull_type = DropRepeats)
 export droprepeats
 
-(pa::PullAction{DropRepeats,A})(s) where A = begin
+function (pa::PullAction{DropRepeats,A})(s) where A
     args = pull_args(pa)
     if !valid(s)
         old_val = value(s)
@@ -31,13 +31,13 @@ remove updates from the `signal` where `f` does not return `true`. The filter wi
 the value default until f(value(signal)) returns true, when it will be updated
 to value(signal).
 """
-filter(f::Function,v0,s::Signal) = begin
+function filter(f::Function,v0,s::Signal)
     sd = SignalData(f(s[]) ? s[] : v0)
     action = PullAction(f,(s,),Filter)
     Signal(sd,action)
 end
 
-(pa::PullAction{Filter,Tuple{Signal}})(s) = begin
+function (pa::PullAction{Filter,Tuple{Signal}})(s)
     source_val = pull!(pa.args[1])
     if !valid(s)
         if pa.f(source_val) == true
@@ -72,7 +72,7 @@ the time of creation the signal will be initialized to value `v0`
     julia> A(12)
     12
 """
-when(f::Function,condition::Signal,args...; v0 = nothing) = begin
+function when(f::Function,condition::Signal,args...; v0 = nothing)
     action = PullAction(f,args,When)
     sd = SignalData(condition() ? action() : v0)
     s = Signal(sd,action,condition)
@@ -81,7 +81,7 @@ when(f::Function,condition::Signal,args...; v0 = nothing) = begin
 end
 export when
 
-(pa::PullAction{When,A})(s) where A = begin
+function (pa::PullAction{When,A})(s) where A
     condition = state(s)
     args = pull_args(pa)
     if !valid(s)
@@ -140,7 +140,7 @@ function merge(in1::Signal, rest::Signal...)
     Signal(sd,action)
 end
 
-(pa::PullAction{Merge,A})(s) where A = begin
+function (pa::PullAction{Merge,A})(s) where A
     res = s[]
     for arg in pa.args
         if !valid(arg)
@@ -197,7 +197,7 @@ function recursion_free(f::Function,args...)
 end
 export recursion_free
 
-(pa::PullAction{RecursionFree,A})(s) where A = begin
+function (pa::PullAction{RecursionFree,A})(s) where A
     if s.state.x == true
         validate(s.data)
         validate(s)

--- a/src/pushpull.jl
+++ b/src/pushpull.jl
@@ -70,7 +70,7 @@ pull!(x) = x
 action(s::Signal) =  s.action(s)
 
 abstract type StandardPull <: PullType end
-(pa::PullAction{StandardPull,ARGS})(s::Signal) where ARGS = begin
+function (pa::PullAction{StandardPull,ARGS})(s::Signal) where ARGS
     args = pull_args(pa)
     if !valid(s)
         store!(s,pa())

--- a/src/time.jl
+++ b/src/time.jl
@@ -59,7 +59,7 @@ function throttle(f::Function,args... ; maxfps = 30)
 end
 export throttle
 
-(pa::PullAction{Throttle,A})(s) where A = begin
+function (pa::PullAction{Throttle,A})(s) where A
     (dt,last_update) = s.state.x
     args = pull_args(pa)
     if !valid(s)
@@ -73,7 +73,7 @@ export throttle
     value(s)
 end
 
-activate_timer(s,dt,duration) = begin
+function activate_timer(s,dt,duration)
     signalref = WeakRef(Ref(s))
     start_time = time()
     t = Timer(dt,dt) do t


### PR DESCRIPTION
Not sure about this one, maybe there is a reason to use begin..end?

This said, acc. to the manual (and code I grepped in Julia base and elsewhere) multiline functions do not use begin..end blocks. Also true for anonymous functions. This PR is a suggestion to drop these blocks and use the normal function form.

(Hope I don't miss something)